### PR TITLE
small improvements

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -2,8 +2,13 @@
 	{
 		"caption": "-"
 	}, {
-		"caption": "XPath: Copy path to clipboard",
-		"command": "xpath"
+		"caption": "XPath: Copy exact path to clipboard",
+		"command": "xpath",
+		"args":	{ "show_hierarchy_only": false }
+	}, {
+		"caption": "XPath: Copy hierarchy to clipboard",
+		"command": "xpath",
+		"args":	{ "show_hierarchy_only": true }
 	}, {
 		"caption": "-"
 	}

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,9 +4,13 @@
 		"command": "xpath",
 		"args":	{ "show_hierarchy_only": false }
 	}, {
-		"caption": "XPath: Copy hierarchy to clipboard",
+		"caption": "XPath: Copy hierarchy without attributes to clipboard",
 		"command": "xpath",
-		"args":	{ "show_hierarchy_only": true }
+		"args":	{ "show_hierarchy_only": true, "show_attributes_in_hierarchy": false }
+	}, {
+		"caption": "XPath: Copy hierarchy with attributes to clipboard",
+		"command": "xpath",
+		"args":	{ "show_hierarchy_only": true, "show_attributes_in_hierarchy": true }
 	}, {
 		"caption": "XPath: Goto previous sibling",
 		"command": "goto_relative", "args": { "direction": "prev" }

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Sublime Text - XPath Plugin
 See [default settings](https://github.com/rosshadden/sublime-xpath/blob/master/xpath.sublime-settings) for details and default values.
 
 - `show_hierarchy_only` - Whether to show only hierarchy in status bar, instead of exact xpath.
-- `show_all_attributes` - Whether to show attributes in the path.  Can show all of them, or a provided whitelist.
-> This is ignored if only the hierarchy is shown.
-- `case_sensitive` - Whether to ignore case when determining tag index and whether an attribute matches one defined in the preferences.
+- `show_all_attributes` - Whether to show all attributes in the path.  If false, will use a provided whitelist.
+- `case_sensitive` - Whether to ignore case when determining tag index and whether an attribute matches one defined in the whitelist.
 - `copy_unique_path_only` - Whether to copy only unique xpaths to the clipboard when there are multiple selections.
 - `attributes_to_include` - Specific attributes or namespaces to include in the XPath.
+- `show_attributes_in_hierarchy` - Whether or not to include attributes when in hierarchy mode. (If `show_all_attributes` is false and the `attributes_to_include` whitelist is empty, this will have no effect.)
 
 
 ## Potential future improvements:

--- a/xpath.py
+++ b/xpath.py
@@ -167,14 +167,8 @@ def getXPathStringAtPositions(view, positions, includeIndexes, includeAttributes
 
 def isSGML(view):
     """Return True if the view's syntax is XML or HTML."""
-    currentSyntax = view.settings().get('syntax')
-    if currentSyntax is not None:
-        XMLSyntax = 'Packages/XML/'
-        HTMLSyntax = 'Packages/HTML/'
-        global supportHTML
-        return currentSyntax.startswith(XMLSyntax) or (supportHTML and currentSyntax.startswith(HTMLSyntax))
-    else:
-        return False
+    global supportHTML
+    return view.score_selector(0, 'text.xml') > 0 or (supportHTML and view.score_selector(0, 'text.html') > 0)
 
 def updateStatusIfSGML(view):
     """Update the status bar with the relevant xpath at the cursor if the syntax is XML."""

--- a/xpath.py
+++ b/xpath.py
@@ -208,7 +208,8 @@ def updateStatus(view):
         text = intro + ': ' + showPath
         maxLength = 236 # if status message is longer than this, sublime text 3 shows nothing in the status bar at all, so unfortuantely we have to truncate it...
         if len(text) > maxLength:
-            text = text[0:maxLength]
+            append = ' (truncated)'
+            text = text[0:maxLength - len(append)] + append
         view.set_status('xpath', text)
     else:
         view.erase_status('xpath')

--- a/xpath.py
+++ b/xpath.py
@@ -172,9 +172,9 @@ def getXPathStringAtPositions(view, positions, includeIndexes, includeAttributes
     return matches
 
 def isSGML(view):
-    """Return True if the view's syntax is XML or HTML."""
+    """Return True if the view contains XML or HTML syntax."""
     global supportHTML
-    return view.score_selector(0, 'text.xml') > 0 or (supportHTML and view.score_selector(0, 'text.html') > 0)
+    return len(view.find_by_selector('text.xml')) > 0 or (supportHTML and len(view.find_by_selector('text.html')) > 0)
 
 def updateStatusIfSGML(view):
     """Update the status bar with the relevant xpath at the cursor if the syntax is XML."""

--- a/xpath.py
+++ b/xpath.py
@@ -31,11 +31,17 @@ def buildPathsForView(view):
     global XPaths
     XPaths[view.id()] = []
     
+    # find all xml and html scopes in the view
+    for region in view.find_by_selector('text.xml') + view.find_by_selector('text.html'):
+        buildPathsForViewRegion(view, region)
+
+def buildPathsForViewRegion(view, region_scope):
+    """Create a cache of all xpaths for the XML in the specified view region."""
     path = ['']
     levelCounters = [{}]
     firstIndexInXPath = 1
     
-    tagRegions = view.find_by_selector('entity.name.tag.')
+    tagRegions = [region for region in view.find_by_selector('entity.name.tag.') if region_scope.contains(region)] # find all entity name tags within the specified scope
     position = 0
     
     global settings
@@ -198,7 +204,12 @@ def updateStatus(view):
         intro = 'XPath'
         if len(view.sel()) > 1:
             intro = intro + ' (at first selection)'
-        view.set_status('xpath', intro + ': ' + showPath)
+        
+        text = intro + ': ' + showPath
+        maxLength = 236 # if status message is longer than this, sublime text 3 shows nothing in the status bar at all, so unfortuantely we have to truncate it...
+        if len(text) > maxLength:
+            text = text[0:maxLength]
+        view.set_status('xpath', text)
     else:
         view.erase_status('xpath')
 

--- a/xpath.sublime-settings
+++ b/xpath.sublime-settings
@@ -10,8 +10,10 @@
 	"show_all_attributes": false,
 	// whether tags and attributes should be treated as case sensitive for index purposes
 	"case_sensitive": true,
-	// show only the hierarchy (without indexes and attributes) in the status bar
+	// show only the hierarchy (without indexes) in the status bar
 	"show_hierarchy_only": false,
+	// when in hierarchy mode, whether to include attributes or not
+	"show_attributes_in_hierarchy": false,
 	// only copy unique xpaths when there are multiple selections
 	"copy_unique_path_only": true
 }


### PR DESCRIPTION
Hi,

I thought it might be nicer to give users the option of whether or not to include attributes in the hierarchy mode.  The usage case I'm thinking of is wanting to reference elements by attribute but not index.

I have also updated the context menu to include a separate menu item for copying the hierarchy, as opposed to the exact xpath, as discussed in issue #5 .