### PR TITLE
allow key bindings to select results from specific xpath query

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Sublime Text - XPath Plugin
   - display results in real-time (i.e. as you type the query, fitting in perfectly with Sublime's other actions). (With an option to customize this, if desired.)
   - [move the cursor to the highlighted result.](#cursor_to_highlighted_result_demo)
   - [reference multiple context nodes](#multiple_contexts_demo) (at cursor positions) by using the `$contexts` variable.
-  - [Re-run the previous query and select all the corresponding nodes in the document.](#select_all_results_demo) (Note that it doesn't preserve the context nodes at the moment.)
+  - [Execute a query and select all the corresponding nodes in the document.](#select_all_results_demo) (There is an entry in the command palette to re-run the previous query and select all results, but please note that it doesn't preserve the context nodes at the moment.)
   - with history, optionally globally or per document.
   - optionally normalize whitespace when displaying text results (via a setting).
   - define custom variables in the settings file.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Feature requests, bug reports/fixes and usability suggestions are always welcome
 
 In no particular order, here are some ideas of how this plugin could be made even more awesome:
 
+- Option to select attribute values (or the entire attribute definition) when attribute nodes are returned from an XPath query. (It currently only selects the element they belong to)
+- Option to change what is selected when the cursor is moved to an element. (So that it can select both the open and the close tag for example).
 - Improve syntax highlighting (and therefore also auto completion) accuracy.
 - Optimize for when modifications to the underlying XML document are made by the user, especially changes that don't alter the document structure. Currently, the whole document is re-parsed on every tiny little change (i.e. every character press while typing). (although many changes in quick succession means it will abort an in-progress parse to start again with the latest changes included.)
 - Integrate with the awesome [BracketHighlighter plugin](https://packagecontrol.io/packages/BracketHighlighter)? For efficiency - as we have already stored the location of each tag - and it will get round the large distance between tags limitation that BH has.  It could also remove some duplicate navigation functionality when both plugins are installed.

--- a/xpath.py
+++ b/xpath.py
@@ -642,6 +642,7 @@ class SelectResultsFromXpathQueryCommand(sublime_plugin.TextCommand): # example 
             sublime.status_message(str(total_results) + ' nodes selected')
         else:
             sublime.status_message(str(total_selections) + ' nodes selected out of ' + str(total_results))
+        add_to_xpath_query_history_for_key(get_history_key_for_view(self.view), kwargs['xpath'])
 
 class RerunLastXpathQueryAndSelectResultsCommand(sublime_plugin.TextCommand): # example usage from python console: sublime.active_window().active_view().run_command('rerun_last_xpath_query_and_select_results', { 'global_query_history': False })
     def run(self, edit, **args):

--- a/xpath.py
+++ b/xpath.py
@@ -633,6 +633,16 @@ def namespace_map_for_tree(tree):
     namespaces = unique_namespace_prefixes(get_all_namespaces_in_tree(tree), defaultNamespacePrefix)
     return namespaces
 
+class SelectResultsFromXpathQueryCommand(sublime_plugin.TextCommand): # example usage from python console: sublime.active_window().active_view().run_command('select_results_from_xpath_query', { 'xpath': '//*' })
+    def run(self, edit, **kwargs):
+        contexts = get_context_nodes_from_cursors(self.view)
+        nodes = get_results_for_xpath_query_multiple_trees(kwargs['xpath'], contexts, namespace_map_from_contexts(contexts))
+        total_selections, total_results = move_cursors_to_nodes(self.view, nodes, 'open')
+        if total_results == total_selections:
+            sublime.status_message(str(total_results) + ' nodes selected')
+        else:
+            sublime.status_message(str(total_selections) + ' nodes selected out of ' + str(total_results))
+
 class RerunLastXpathQueryAndSelectResultsCommand(sublime_plugin.TextCommand): # example usage from python console: sublime.active_window().active_view().run_command('rerun_last_xpath_query_and_select_results', { 'global_query_history': False })
     def run(self, edit, **args):
         global_history = getBoolValueFromArgsOrSettings('global_query_history', args, True)
@@ -646,13 +656,7 @@ class RerunLastXpathQueryAndSelectResultsCommand(sublime_plugin.TextCommand): # 
         if len(history) == 0:
             sublime.status_message('no previous query to re-run')
         else:
-            contexts = get_context_nodes_from_cursors(self.view)
-            nodes = get_results_for_xpath_query_multiple_trees(history[-1], contexts, namespace_map_from_contexts(contexts))
-            total_selections, total_results = move_cursors_to_nodes(self.view, nodes, 'open')
-            if total_results == total_selections:
-                sublime.status_message(str(total_results) + ' nodes selected')
-            else:
-                sublime.status_message(str(total_selections) + ' nodes selected out of ' + str(total_results))
+            self.view.run_command('select_results_from_xpath_query', { 'xpath': history[-1] })
     
     def is_enabled(self, **args):
         return isCursorInsideSGML(self.view)


### PR DESCRIPTION
Hi Ross,

I have made a small refactor to allow key bindings to be created to execute a specific xpath query and select all the results in the document.

Previously it was only possible to select all the results of the last xpath query that was executed.