### PR TITLE
more options for cursor movement to XPath results

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ See [default settings](https://github.com/rosshadden/sublime-xpath/blob/master/x
 - `variables` - a dictionary of custom variables, which can be used when writing an XPath query expression.
 - `auto_completion_triggers` - characters that, when typed while entering an XPath expression, will automatically show autocompletions. If empty, autocompletion can still be triggered manually.
 - `intelligent_auto_complete` - whether or not to include intelligent autocompletion suggestions from the document.
+- `goto_element` - when an element is selected via an XPath query, which aspect of it the cursor should move to. Possible values are:
+  - `open` - Select the name of the element in the open tag.
+  - `close` - Select the name of the element in the close tag.
+  - `names` - Select the name of the element in both the open and the close tag.
+  - `open_attributes` - Select all the attributes in the open tag.
+  - `content` - Select the content of the element.
+  - `entire` - Select the entire element i.e. it's open tag, contents and close tag.
+  - `none` - Do not move the cursor.
+- `goto_attribute` - when an attribute is selected via an XPath query, which aspect of it the cursor should move to. Possible values are:
+  - `name` - Select the name of the attribute.
+  - `value` - Select the value (inside the quotes) of the attribute.
+  - `entire` - Select the name and the value of the attribute.
+  - `element` - Select the element that the attribute belongs to, using the `goto_element` rules.
+  - `none` - Do not move the cursor.
 
 <a name="demos"></a>
 ## Demonstrations
@@ -73,8 +87,6 @@ Feature requests, bug reports/fixes and usability suggestions are always welcome
 
 In no particular order, here are some ideas of how this plugin could be made even more awesome:
 
-- Option to select attribute values (or the entire attribute definition) when attribute nodes are returned from an XPath query. (It currently only selects the element they belong to)
-- Option to change what is selected when the cursor is moved to an element. (So that it can select both the open and the close tag for example).
 - Improve syntax highlighting (and therefore also auto completion) accuracy.
 - Optimize for when modifications to the underlying XML document are made by the user, especially changes that don't alter the document structure. Currently, the whole document is re-parsed on every tiny little change (i.e. every character press while typing). (although many changes in quick succession means it will abort an in-progress parse to start again with the latest changes included.)
 - Integrate with the awesome [BracketHighlighter plugin](https://packagecontrol.io/packages/BracketHighlighter)? For efficiency - as we have already stored the location of each tag - and it will get round the large distance between tags limitation that BH has.  It could also remove some duplicate navigation functionality when both plugins are installed.

--- a/lxml_parser.py
+++ b/lxml_parser.py
@@ -28,16 +28,16 @@ def lxml_etree_parse_xml_string_with_location(xml_string, line_number_offset, sh
         def setDocumentLocator(self, locator):
             self._locator = locator
         
-        def _splitPrefixAndGetNamespaceURI(self, fullName):
+        def _splitPrefixAndGetNamespaceURI(self, full_name):
             prefix = None
             local_name = None
             
-            split_pos = fullName.find(':')
+            split_pos = full_name.find(':')
             if split_pos > -1:
-                prefix = fullName[0:split_pos]
-                local_name = fullName[split_pos + 1:]
+                prefix = full_name[0:split_pos]
+                local_name = full_name[split_pos + 1:]
             else:
-                local_name = fullName
+                local_name = full_name
             
             return (prefix, local_name, self._getNamespaceURI(prefix))
         
@@ -58,7 +58,7 @@ def lxml_etree_parse_xml_string_with_location(xml_string, line_number_offset, sh
             locator = self._locator or parser
             return str(locator.getLineNumber() - 1 + line_number_offset) + '/' + str(locator.getColumnNumber())
         
-        def startElementNS(self, name, tagName, attrs):
+        def startElementNS(self, name, tag_name, attrs):
             self._recordEndPosition()
             
             self._last_action = 'open'
@@ -84,11 +84,11 @@ def lxml_etree_parse_xml_string_with_location(xml_string, line_number_offset, sh
                 attrs.pop(attr[0]) # remove the attribute
                 attrs[(attr[1][2], attr[1][1])] = attr[2] # re-add the attribute with the correct qualified name
             
-            tag = self._splitPrefixAndGetNamespaceURI(tagName)
+            tag = self._splitPrefixAndGetNamespaceURI(tag_name)
             name = (tag[2], tag[1])
             
             self._new_mappings = self._getNamespaceMap()
-            super().startElementNS(name, tagName, attrs)
+            super().startElementNS(name, tag_name, attrs)
             
             current = self._element_stack[-1]
             self._recordPosition(current, 'open_tag_start_pos')
@@ -113,7 +113,7 @@ def lxml_etree_parse_xml_string_with_location(xml_string, line_number_offset, sh
             if prefix is None:
                 self._default_ns = self._getNamespaceURI(None)
         
-        def endElementNS(self, name, tagName):
+        def endElementNS(self, name, tag_name):
             self._recordEndPosition()
             
             self._last_action = 'close'
@@ -121,9 +121,9 @@ def lxml_etree_parse_xml_string_with_location(xml_string, line_number_offset, sh
             current = self._element_stack[-1]
             self._recordPosition(current, 'close_tag_start_pos')
             
-            tag = self._splitPrefixAndGetNamespaceURI(tagName)
+            tag = self._splitPrefixAndGetNamespaceURI(tag_name)
             name = (tag[2], tag[1])
-            super().endElementNS(name, tagName)
+            super().endElementNS(name, tag_name)
             if None in self._prefix_hierarchy[-1]: # re-map default namespace if applicable
                 self.endPrefixMapping(None)
             self._prefix_hierarchy.pop()

--- a/lxml_parser.py
+++ b/lxml_parser.py
@@ -261,6 +261,9 @@ def get_results_for_xpath_query(query, tree, context = None, namespaces = None, 
     if namespaces is not None:
         for prefix in namespaces.keys():
             nsmap[prefix] = namespaces[prefix][0]
+    
+    global ns_loc
+    query += '[namespace-uri() != "' + ns_loc + '"]'
     xpath = etree.XPath(query, namespaces = nsmap)
     
     results = execute_xpath_query(tree, xpath, context, **variables)

--- a/sublime_input.py
+++ b/sublime_input.py
@@ -90,6 +90,26 @@ class RequestInputCommand(sublime_plugin.TextCommand): # this command should be 
     
     def on_query_completions(self, prefix, locations): # http://docs.sublimetext.info/en/latest/reference/api.html#sublime_plugin.EventListener.on_query_completions
         pass
+    
+    def refresh_selection_bug_work_around(self):
+        # https://github.com/SublimeTextIssues/Core/issues/485
+        # refresh_selection_bug_work_around() provides a workaround for the Sublime
+        # Text bug whereby selections do not always get displayed correctly
+        # immediately after being altered by a plugin.
+        
+        # Adding and then removing an empty list of regions in the view
+        # ensures that all selections are refreshed and displayed correctly.
+        # Using an actual list of regions say, self.view.sel(), also works.
+        
+        empty_list = []
+        
+        bug_reg_key = 'selection_bug_demo_workaround_regions_key'
+        
+        self.view.add_regions(bug_reg_key, empty_list, 'no_scope', '', sublime.HIDDEN)
+        
+        self.view.erase_regions(bug_reg_key)
+        
+    # End of def refreshSelectionBugWorkAround()
 
 class InputCompletionsListener(sublime_plugin.EventListener):
     def on_query_completions(self, view, prefix, locations):

--- a/sublime_lxml.py
+++ b/sublime_lxml.py
@@ -111,7 +111,6 @@ def get_nodes_from_document(nodes):
             continue # unsupported type
         
         key = next((key for key in element.attrib.keys() if key.startswith('{' + ns_loc + '}')), None)
-        print(key)
         # some nodes are not actually part of the original document we parsed, for example when using the substring function. so there is no way to find the original node, and therefore the location
         if key is not None:
             yield node

--- a/sublime_lxml.py
+++ b/sublime_lxml.py
@@ -88,11 +88,11 @@ def getNodesAtPositions(view, roots, positions):
     for root in roots:
         if root is not None:
             last_match_index = len(positions) - 1
-            get_matches_in_tree = True
-            if len(roots) > 1: # if there is only one tree, we can skip the optimization check, because we know for sure the matches will be in the tree
-                open_pos, close_pos = getNodePosition(view, root)
-                root_matches, start_match_index, last_match_index = matchSpan(open_pos.cover(close_pos), start_match_index, last_match_index, True)
-                get_matches_in_tree = len(root_matches) > 0 # determine if it is worth checking this tree
+            
+            open_pos, close_pos = getNodePosition(view, root)
+            root_matches, start_match_index, last_match_index = matchSpan(open_pos.cover(close_pos), start_match_index, last_match_index, True)
+            get_matches_in_tree = len(root_matches) > 0 # determine if it is worth checking this tree
+                
             if get_matches_in_tree: # skip the tree if it doesn't participate in the match (saves iterating through all children of root element unnecessarily)
                 start_match_index = getMatches(root, start_match_index, last_match_index, matches)
     

--- a/sublime_lxml.py
+++ b/sublime_lxml.py
@@ -168,6 +168,9 @@ def get_regions_of_nodes(view, nodes, element_position_type, attribute_position_
             # position type 'content' <element attr1="|test|"></element> "Goto attribute value in open tag"
             # position type 'entire' <element |attr1="test"|></element> "Goto attribute declaration in open tag"
             
+            if attrname.startswith('{'):
+                attrname = '\w+:' + attrname.split('}')[1] # NOTE: will currently get the wrong attribute in some (rare?) situations with two attributes with the same local name belonging to the same element, for example if there is something like <element abc:foo="hello" bar:foo="world" /> because it doesn't check the prefix or the namespace uri
+            
             tag = getTagName(node)[2]
             chars_before = len('<') + len(tag)
             attrs = ' ' + view.substr(sublime.Region(open_pos.begin() + chars_before, open_pos.end()))

--- a/xpath.py
+++ b/xpath.py
@@ -867,6 +867,7 @@ class QueryXpathCommand(QuickPanelFromInputCommand): # example usage from python
     def quickpanel_selection_changed(self, selected_index):
         if selected_index > -1: # quick panel wasn't cancelled
             move_cursors_to_nodes(self.view, [self.items[selected_index]], self.arguments['goto_element'], self.arguments['goto_attribute'])
+            self.refresh_selection_bug_work_around()
             #self.view.window().focus_view(self.view) # focus the view to try getting the cursor positions to update while the quick panel is open
             #if self.input_panel is not None:
             #    self.input_panel.window().focus_view(self.input_panel)

--- a/xpath.py
+++ b/xpath.py
@@ -755,16 +755,23 @@ class QueryXpathCommand(QuickPanelFromInputCommand): # example usage from python
         """Cache context nodes to allow live mode to work with them."""
         context_nodes = get_context_nodes_from_cursors(self.view)
         self.contexts = (self.view.change_count(), context_nodes, namespace_map_from_contexts(context_nodes))
+        
+        tree_count = 0
         for root in context_nodes:
+            tree_count += 1
+            
             print('XPath context nodes: ', getExactXPathOfNodes(context_nodes[root]))
         
-        # attempt to highlight the context node in the quick panel by default so that the cursor doesn't move (far)
-        try:
-            self.highlighted_result = context_nodes[next(iter(context_nodes.keys()))][0]
+        self.highlighted_result = None
+        self.highlighted_index = -1
+        
+        if tree_count == 1: # if there is exactly one xml tree
+            tree = next(iter(context_nodes.keys())) # get the tree
+            if len(context_nodes[tree]) == 0: # if there are no context nodes
+                context_nodes[tree].append(tree.getroot()) # use the root element as the context node
+            # attempt to highlight the context node in the quick panel by default so that the cursor doesn't move (far)
+            self.highlighted_result = context_nodes[tree][0]
             self.highlighted_index = 0
-        except:
-            self.highlighted_result = None
-            self.highlighted_index = -1
         
     def run(self, edit, **args):
         self.cache_context_nodes()

--- a/xpath.py
+++ b/xpath.py
@@ -865,6 +865,7 @@ class QueryXpathCommand(QuickPanelFromInputCommand): # example usage from python
         return [show_preview(item) for item in results]
         
     def quickpanel_selection_changed(self, selected_index):
+        super().quickpanel_selection_changed(selected_index)
         if selected_index > -1: # quick panel wasn't cancelled
             move_cursors_to_nodes(self.view, [self.items[selected_index]], self.arguments['goto_element'], self.arguments['goto_attribute'])
             self.refresh_selection_bug_work_around()

--- a/xpath.py
+++ b/xpath.py
@@ -759,8 +759,12 @@ class QueryXpathCommand(QuickPanelFromInputCommand): # example usage from python
             print('XPath context nodes: ', getExactXPathOfNodes(context_nodes[root]))
         
         # attempt to highlight the context node in the quick panel by default so that the cursor doesn't move (far)
-        self.highlighted_result = context_nodes[next(iter(context_nodes.keys()))][0]
-        self.highlighted_index = 0
+        try:
+            self.highlighted_result = context_nodes[next(iter(context_nodes.keys()))][0]
+            self.highlighted_index = 0
+        except:
+            self.highlighted_result = None
+            self.highlighted_index = -1
         
     def run(self, edit, **args):
         self.cache_context_nodes()

--- a/xpath.py
+++ b/xpath.py
@@ -652,7 +652,7 @@ class SelectResultsFromXpathQueryCommand(sublime_plugin.TextCommand): # example 
             goto_attribute = kwargs['goto_attribute']
         
         total_selections, total_results = move_cursors_to_nodes(self.view, nodes, goto_element, goto_attribute)
-        if total_results == total_selections:
+        if total_selections == total_results: # NOTE: the number reported in the status bar (below) is wrong when there are multiple selections per node
             sublime.status_message(str(total_results) + ' nodes selected')
         else:
             sublime.status_message(str(total_selections) + ' nodes selected out of ' + str(total_results))

--- a/xpath.py
+++ b/xpath.py
@@ -651,11 +651,11 @@ class SelectResultsFromXpathQueryCommand(sublime_plugin.TextCommand): # example 
         if 'goto_attribute' in kwargs:
             goto_attribute = kwargs['goto_attribute']
         
-        total_selections, total_results = move_cursors_to_nodes(self.view, nodes, goto_element, goto_attribute)
-        if total_selections == total_results: # NOTE: the number reported in the status bar (below) is wrong when there are multiple selections per node
+        total_selectable_results, total_results = move_cursors_to_nodes(self.view, nodes, goto_element, goto_attribute)
+        if total_selectable_results == total_results:
             sublime.status_message(str(total_results) + ' nodes selected')
         else:
-            sublime.status_message(str(total_selections) + ' nodes selected out of ' + str(total_results))
+            sublime.status_message(str(total_selectable_results) + ' nodes selected out of ' + str(total_results))
         add_to_xpath_query_history_for_key(get_history_key_for_view(self.view), kwargs['xpath'])
 
 class RerunLastXpathQueryAndSelectResultsCommand(sublime_plugin.TextCommand): # example usage from python console: sublime.active_window().active_view().run_command('rerun_last_xpath_query_and_select_results', { 'global_query_history': False })

--- a/xpath.py
+++ b/xpath.py
@@ -757,7 +757,11 @@ class QueryXpathCommand(QuickPanelFromInputCommand): # example usage from python
         self.contexts = (self.view.change_count(), context_nodes, namespace_map_from_contexts(context_nodes))
         for root in context_nodes:
             print('XPath context nodes: ', getExactXPathOfNodes(context_nodes[root]))
-    
+        
+        # attempt to highlight the context node in the quick panel by default so that the cursor doesn't move (far)
+        self.highlighted_result = context_nodes[next(iter(context_nodes.keys()))][0]
+        self.highlighted_index = 0
+        
     def run(self, edit, **args):
         self.cache_context_nodes()
         if len(self.contexts[1].keys()) == 0: # if there are no context nodes, don't proceed to show the xpath input panel

--- a/xpath.sublime-settings
+++ b/xpath.sublime-settings
@@ -37,5 +37,9 @@
 	// characters that, when typed in the xpath expression input panel, will automatically trigger autocompletions. If empty, autocompletion can still be triggered manually
 	"auto_completion_triggers": "'/[$@:( '",
 	// whether or not to include intelligent autocompletion suggestions from the document
-	"intelligent_auto_complete": true
+	"intelligent_auto_complete": true,
+	// when an element is selected via an XPath query, what aspect of it should the cursor move to? possible values: open, close, names, open_attributes, content, entire
+	"goto_element": "open",
+	// when an attribute is selected via an XPath query, what aspect of it should the cursor move to? possible values: name, value, entire
+	"goto_attribute": "value"
 }


### PR DESCRIPTION
Hi Ross,

Firstly, sorry for all the pull requests - you can see that I like adding features!

I have fixed a bug with auto completion of attributes that have a namespace prefix.
I have added support for moving the cursors to attributes and text nodes.  In addition, I have added configuration settings to control this behavior, or even disable it if desired.  See the readme for details :)

Thanks!
