### PR TITLE
refactor exclusions of internal nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Feature requests, bug reports/fixes and usability suggestions are always welcome
 
 In no particular order, here are some ideas of how this plugin could be made even more awesome:
 
+- Research using a custom Element class and keeping the proxies alive instead of storing metadata in attributes - see http://lxml.de/element_classes.html#element-initialization.
 - Improve syntax highlighting (and therefore also auto completion) accuracy.
 - Optimize for when modifications to the underlying XML document are made by the user, especially changes that don't alter the document structure. Currently, the whole document is re-parsed on every tiny little change (i.e. every character press while typing). (although many changes in quick succession means it will abort an in-progress parse to start again with the latest changes included.)
 - Integrate with the awesome [BracketHighlighter plugin](https://packagecontrol.io/packages/BracketHighlighter)? For efficiency - as we have already stored the location of each tag - and it will get round the large distance between tags limitation that BH has.  It could also remove some duplicate navigation functionality when both plugins are installed.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The recommended way to install the Sublime Text XPath plugin is via [Package Con
 1. Restart Sublime Text to be sure everything is loaded properly.
 1. Enjoy!
 
+## Known Quirks
+
+Unfortunately, Python isn't very good at processing xml. The lxml library doesn't surface column positions of the nodes etc. and attribute prefixes are lost, with just namespace uri retained. To make matters worse, it isn't possible to store custom metadata on a node. To overcome these limitations, this plugin stores the necessary information in element attribute nodes with a separate namespace. This works well, but it has the side effect of impacting the XPath query results. Where possible, they have been filtered out before the plugin returns the data to the user. But there are some quirks. For example, the count of attributes will always be wrong using `count(@*)`. To work around this, you can exclude attributes in the `lxml` namespace like this: `count(@*[namespace-uri() != 'lxml'])`
+
 ## Potential future improvements:
 
 Feature requests, bug reports/fixes and usability suggestions are always welcome.

--- a/lxml_parser.py
+++ b/lxml_parser.py
@@ -269,8 +269,6 @@ def get_results_for_xpath_query(query, tree, context = None, namespaces = None, 
         for prefix in namespaces.keys():
             nsmap[prefix] = namespaces[prefix][0]
     
-    global ns_loc
-    query += '[namespace-uri() != "' + ns_loc + '"]'
     xpath = etree.XPath(query, namespaces = nsmap)
     
     results = execute_xpath_query(tree, xpath, context, **variables)

--- a/sublime_lxml.py
+++ b/sublime_lxml.py
@@ -104,8 +104,6 @@ def filter_out_internal_nodes(nodes):
         if isinstance(node, etree._ElementUnicodeResult): # if the node is an attribute or text node etc.
             if node.attrname is not None and node.attrname.startswith('{' + ns_loc + '}'): # skip our internally created attributes
                 continue
-        elif not isinstance(node, etree._Element):
-            continue # unsupported type
         
         yield node
 


### PR DESCRIPTION
fixes some bugs whereby attributes that don't exist in the document (i.e. the attributes I created to keep track of tag positions etc.) were showing up in results etc.
I had a workaround previously, but it caused some other things to not work. My fault for adding that workaround to the previous pull request while I was still developing it, and thus before I did complete tests!