### PR TITLE
fix #22

### DIFF
--- a/lxml_parser.py
+++ b/lxml_parser.py
@@ -77,17 +77,20 @@ class LocationAwareXMLParser:
         
         for result in self.RE_SPLIT_XML.finditer(chunk, start_search_at): # find the next sigificant XML control char, so we can manually know the location
             self._positions.append((self._position_offset + chunk_offset, self._position_offset + result.start()))
-            self._parser.feed(chunk[chunk_offset:result.start()])
+            self._feed(chunk[chunk_offset:result.start()])
             
             self._positions.append((self._position_offset + result.start(), self._position_offset + result.end()))
-            self._parser.feed(chunk[result.start():result.end()])
+            self._feed(chunk[result.start():result.end()])
             chunk_offset = result.end()
         self._remainder = chunk[chunk_offset:]
         self._position_offset += chunk_offset
     
+    def _feed(self, text):
+        self._parser.feed(bytes(text, 'UTF-8'))
+    
     def close(self):
         self._positions.append((self._position_offset, self._position_offset + len(self._remainder)))
-        self._parser.feed(self._remainder)
+        self._feed(self._remainder)
         result = self._parser.close()
         self._reset()
         return result

--- a/lxml_parser.py
+++ b/lxml_parser.py
@@ -86,7 +86,7 @@ class LocationAwareXMLParser:
         self._position_offset += chunk_offset
     
     def _feed(self, text):
-        self._parser.feed(bytes(text, 'UTF-8'))
+        self._parser.feed(bytes(text, 'UTF-8')) # feed as bytes, otherwise doesn't work on OSX, and encoding declarations in the prolog can cause exceptions
     
     def close(self):
         self._positions.append((self._position_offset, self._position_offset + len(self._remainder)))

--- a/lxml_parser.py
+++ b/lxml_parser.py
@@ -86,7 +86,7 @@ class LocationAwareXMLParser:
         self._position_offset += chunk_offset
     
     def _feed(self, text):
-        self._parser.feed(bytes(text, 'UTF-8')) # feed as bytes, otherwise doesn't work on OSX, and encoding declarations in the prolog can cause exceptions
+        self._parser.feed(bytes(text, 'UTF-8')) # feed as bytes, otherwise doesn't work on OSX, and encoding declarations in the prolog can cause exceptions - http://lxml.de/parsing.html#python-unicode-strings
     
     def close(self):
         self._positions.append((self._position_offset, self._position_offset + len(self._remainder)))


### PR DESCRIPTION
fix #22 by converting the unicode string to a bytes object to feed the lxml parser with. Works around the problem that lxml/libxml2 on OSX can't deal with unicode (and all python 3 strings are unicode!...)

I have tested on Windows 7x64 and Ubuntu 15.10 x64 and can confirm everything still works as expected. This change is based on the fact that the Exalt plugin works on OSX using this method.