### PR TITLE
improve display of parse error in status bar and add option to hide it

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Example:
     <hello><![CDATA[world]]><!-- separator, so that the CDATA and text nodes are non-adjacent -->foobar</hello>
 
 The XPath `/hello[1]/text()` on the first example will return a single text node: `worldfoobar`.  On the second example, it will return two text nodes: `world` and `foobar`.
+More information can be found at [this Stack Overflow Q&A](http://stackoverflow.com/questions/36493024/why-does-xpath-not-find-adjacent-text-and-cdata-nodes).
 
 ### Namespaces
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ See [default settings](https://github.com/rosshadden/sublime-xpath/blob/master/x
   - `element` - Select the element that the attribute belongs to, using the `goto_element` rules.
   - `none` - Do not move the cursor.
 - `sgml_selector` - a scope selector to determine what to parse as XML and enable XPath functions for. Defaults to HTML and XML, excluding things like ASP and PHP.
+- `show_xml_parser_errors` - whether or not errors encountered while parsing the document should be shown in the status bar. Disable it if you have other plugins that also show XML parsing/validation errors.
 
 No key bindings are set by default, but an example sublime-keymap file is included, to show the available commands and arguments. [See this documentation](http://docs.sublimetext.info/en/latest/customization/key_bindings.html) for more details about keybindings in ST3.
 

--- a/sublime_input.py
+++ b/sublime_input.py
@@ -24,6 +24,7 @@ class RequestInputCommand(sublime_plugin.TextCommand): # this command should be 
     
     def show_input_panel(self, initial_value):
         self.input_panel = self.view.window().show_input_panel(self.get_value_from_args('label', ''), initial_value, self.input_done, self.input_changed, self.input_cancelled)
+        self.input_panel.set_name('input_panel: ' + self.get_value_from_args('label', ''))
         syntax = self.get_value_from_args('syntax', None)
         if syntax is not None:
             self.input_panel.assign_syntax(syntax)

--- a/sublime_input.py
+++ b/sublime_input.py
@@ -28,6 +28,7 @@ class RequestInputCommand(sublime_plugin.TextCommand): # this command should be 
         if syntax is not None:
             self.input_panel.assign_syntax(syntax)
         self.input_panel.settings().set('gutter', False)
+        self.input_panel.settings().set('highlight_line', False) # in case this bug is ever fixed: https://github.com/SublimeTextIssues/Core/issues/586
         
         global on_query_completions_callbacks
         on_query_completions_callbacks[self.input_panel.id()] = lambda prefix, locations: self.on_query_completions(prefix, locations)

--- a/sublime_lxml.py
+++ b/sublime_lxml.py
@@ -352,7 +352,7 @@ def parse_xpath_query_for_completions(view, completion_position):
 
 def chunks(start, end, chunk_size): # inspired by http://stackoverflow.com/a/18854817/4473405
     """Return a generator that will split the range into chunks of the specified size."""
-    return ((i, i + chunk_size) for i in range(start, end, chunk_size))
+    return ((i, min(i + chunk_size, end)) for i in range(start, end, chunk_size))
 
 def region_chunks(view, region, chunk_size):
     """Return a generator that will split the region into chunks of the specified size."""

--- a/xpath.py
+++ b/xpath.py
@@ -80,10 +80,14 @@ def buildTreeForViewRegion(view, region_scope):
     try:
         tree, all_elements = lxml_etree_parse_xml_string_with_location(region_chunks(view, region_scope, 8096), region_scope.begin(), stop)
     except etree.XMLSyntaxError as e:
-        global parse_error
-        line_number_offset = view.rowcol(region_scope.begin())[0]
-        text = 'line ' + str(e.position[0] + line_number_offset) + ', column ' + str(e.position[1]) + ' - ' + e.msg # TODO: column is incorrect if there are tabs and the tab width is set > 1
-        view.set_status('xpath_error', parse_error + text)
+        global settings
+        show_parse_errors = settings.get('show_xml_parser_errors', True)
+        if show_parse_errors:
+            global parse_error
+            offset = view.rowcol(region_scope.begin())
+            log_entry = e.error_log[0]
+            text = 'line ' + str(log_entry.line + offset[0]) + ', column ' + str(log_entry.column + offset[1]) + ' - ' + log_entry.message
+            view.set_status('xpath_error', parse_error + text)
     
     return (tree, all_elements)
 

--- a/xpath.py
+++ b/xpath.py
@@ -513,6 +513,11 @@ def plugin_loaded():
     
     register_xpath_extensions()
 
+def plugin_unloaded():
+    for view in sublime.active_window().views():
+        view.erase_status('xpath')
+        view.erase_status('xpath_error')
+
 def get_results_for_xpath_query_multiple_trees(query, tree_contexts, root_namespaces, **additional_variables):
     """Given a query string and a dictionary of document trees and their context elements, compile the xpath query and execute it for each document."""
     matches = []

--- a/xpath.sublime-settings
+++ b/xpath.sublime-settings
@@ -43,5 +43,7 @@
 	// when an attribute is selected via an XPath query, what aspect of it should the cursor move to? possible values: name, value, entire
 	"goto_attribute": "value",
 	// which scopes to parse, show XPath at cursors for, and allow XPath queries on
-	"sgml_selector": "text.xml, text.html.basic - embedding.php"
+	"sgml_selector": "text.xml, text.html.basic - embedding.php",
+	// show XML parsing errors in the status bar
+	"show_xml_parser_errors": true,
 }


### PR DESCRIPTION
`lxml` reports the `line` and `column` of parse errors, but by default these appear at the end of the preformatted `msg` - which is confusing because ST shows the line and column of the text caret in the status bar immediately after the xpath status text, and does so in the same format. This PR changes the way the XML parsing error is displayed in the status bar so that this information won't be at the end of the message.

In addition, there is now a setting called `show_xml_parser_errors` which can be set to `false` to not show the error in the status bar. This can be useful when multiple xml related plugins are installed, and a different one also shows the parse errors.

This was reported in https://github.com/rosshadden/sublime-xpath/issues/32