### PR TITLE
syntax improvements

### DIFF
--- a/lxml_parser.py
+++ b/lxml_parser.py
@@ -278,7 +278,8 @@ def get_results_for_xpath_query(query, tree, context = None, namespaces = None, 
     nsmap = {}
     if namespaces is not None:
         for prefix in namespaces.keys():
-            nsmap[prefix] = namespaces[prefix][0]
+            if namespaces[prefix][0] != '':
+                nsmap[prefix] = namespaces[prefix][0]
     
     xpath = etree.XPath(query, namespaces = nsmap)
     

--- a/sublime_lxml.py
+++ b/sublime_lxml.py
@@ -239,13 +239,13 @@ def getElementXMLPreview(view, node, maxlen):
 def parse_xpath_query_for_completions(view, completion_position):
     """Given a view with XPath syntax and a position where completions are desired, parse the xpath query and return the relevant sub queries."""
     
-    selectors = ['punctuation.separator.xpath.arguments', 'punctuation.definition.arguments.begin.xpath.subexpression', 'punctuation.definition.arguments.end.xpath.subexpression', 'punctuation.definition.arguments.begin.xpath.predicate', 'punctuation.definition.arguments.end.xpath.predicate', 'entity.name.function.xpath', 'keyword.operator']
+    selectors = ['punctuation.separator.arguments.xpath', 'punctuation.section.arguments.begin.xpath.subexpression', 'punctuation.section.arguments.end.xpath.subexpression', 'punctuation.section.arguments.begin.xpath.predicate', 'punctuation.section.arguments.end.xpath.predicate', 'variable.function.xpath', 'keyword.operator']
     selector_regions = []
     pos = 0
     for scope in get_scopes(view, 0, completion_position):
         for selector in selectors:
             if selector in scope[0]:
-                if scope[0].endswith('entity.name.function.xpath punctuation.definition.arguments.begin.xpath.subexpression comment '): # combine the function name with the open parenthesis
+                if scope[0].endswith('variable.function.xpath punctuation.section.arguments.begin.xpath.subexpression '): # combine the function name with the open parenthesis
                     selector_regions[-1] = (scope[0], sublime.Region(selector_regions[-1][1].begin(), scope[2] + 1))
                 else:
                     selector_regions.append((None, sublime.Region(pos, scope[1])))

--- a/syntax_test_xpath.syntax-test
+++ b/syntax_test_xpath.syntax-test
@@ -1,42 +1,37 @@
-# SYNTAX TEST "xpath.sublime-syntax"
+(: SYNTAX TEST "xpath.sublime-syntax" :)
 /element1/ns:element2/child::*[position() > 1  and substring-after(., 'hello world') = "test(123)"]/text()
-# <- punctuation.separator.xpath.location_step
-#^^^^^^^^ variable.parameter.xpath
-#        ^ punctuation.separator.xpath.location_step
-#         ^^^^^^^^^^^ variable.parameter.xpath
-#                     ^^^^^^^ constant.language.xpath.axis_name
-#                            ^ variable.parameter.xpath
-#                             ^ xpath.predicate punctuation.definition.arguments.begin.xpath.predicate
-#                              ^^^^^^^^^ meta.function-call.xpath entity.name.function.xpath
-#                                      ^ punctuation.definition.arguments.begin.xpath.subexpression comment
-#                                       ^ meta.function-call.xpath punctuation.definition.arguments.end.xpath.subexpression comment
-#                                        ^ xpath.predicate
-#                                         ^ xpath.predicate keyword.operator.xpath
-#                                          ^ xpath.predicate
-#                                           ^ constant.numeric.xpath
-#                                            ^^ xpath.predicate
-#                                              ^^^ xpath.predicate keyword.operator.xpath
-#                                                  ^^^^^^^^^^^^^^^^ xpath.predicate meta.function-call.xpath entity.name.function.xpath
-#                                                                  ^ xpath.predicate meta.function-call.xpath keyword.control.flow.xpath
-#                                                                   ^ xpath.predicate meta.function-call.xpath punctuation.separator.xpath.arguments
-#                                                                    ^ xpath.predicate meta.function-call.xpath
-#                                                                     ^^^^^^^^^^^^^ xpath.predicate meta.function-call.xpath string.quoted.single.xpath
-#                                                                     ^ xpath.predicate meta.function-call.xpath punctuation.definition.string.begin.xpath
-#                                                                                 ^ xpath.predicate meta.function-call.xpath punctuation.definition.string.end.xpath
-#                                                                                  ^ punctuation.definition.arguments.end.xpath.subexpression comment
-#                                                                                   ^ xpath.predicate
-#                                                                                    ^ xpath.predicate keyword.operator.xpath
-#                                                                                     ^ xpath.predicate
-#                                                                                      ^^^^^^^^^^^ xpath.predicate string.quoted.double.xpath
-#                                                                                      ^^^^ xpath.predicate string.quoted.double.xpath - meta.function-call.xpath
-#                                                                                           ^^^^ xpath.predicate string.quoted.double.xpath - meta.function-call.xpath punctuation.definition.arguments
-#                                                                                      ^ xpath.predicate string.quoted.double.xpath punctuation.definition.string.begin.xpath
-#                                                                                                ^ xpath.predicate string.quoted.double.xpath punctuation.definition.string.end.xpath
-#                                                                                                 ^ xpath.predicate punctuation.definition.arguments.end.xpath.predicate comment
-#                                                                                                  ^ punctuation.separator.xpath.location_step
-#                                                                                                   ^^^^^^ storage.type.xpath.node_type
-#                                                                                                       ^^ storage.type.xpath.node_type - punctuation.definition.arguments
-#                                                                                                   ^^^^^^ storage.type.xpath.node_type - meta.function-call.xpath
+(: <- punctuation.accessor.location_step :)
+(:^^^^^^^ variable.parameter :)
+(:       ^ punctuation.accessor.location_step :)
+(:        ^^^^^^^^^^^ variable.parameter :)
+(:                    ^^^^^^^ constant.language.axis_name :)
+(:                           ^ variable.parameter :)
+(:                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.predicate :)
+(:                                                                                                 ^ - meta.predicate :)
+(:                            ^ punctuation.section.arguments.begin.xpath.predicate :)
+(:                             ^^^^^^^^^^ meta.function-call :)
+(:                             ^^^^^^^^ variable.function :)
+(:                                     ^ punctuation.section.arguments.begin.xpath.subexpression :)
+(:                                      ^ punctuation.section.arguments.end.xpath.subexpression :)
+(:                                        ^ keyword.operator :)
+(:                                          ^ constant.numeric :)
+(:                                             ^^^ keyword.operator :)
+(:                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call :)
+(:                                                                                  ^ - meta.function-call :)
+(:                                                                 ^ keyword.control.flow :)
+(:                                                                  ^ punctuation.separator.arguments :)
+(:                                                                    ^^^^^^^^^^^^^ string.quoted.single :)
+(:                                                                    ^ punctuation.definition.string.begin :)
+(:                                                                                ^ punctuation.definition.string.end :)
+(:                                                                                 ^ punctuation.section.arguments.end.xpath.subexpression :)
+(:                                                                                   ^ keyword.operator :)
+(:                                                                                     ^^^^^^^^^^^ string.quoted.double - meta.function-call :)
+(:                                                                                          ^^^^^ - punctuation :)
+(:                                                                                     ^ punctuation.definition.string.begin :)
+(:                                                                                               ^ punctuation.definition.string.end :)
+(:                                                                                                ^ punctuation.section.arguments.end.xpath.predicate :)
+(:                                                                                                 ^ punctuation.accessor.location_step :)
+(:                                                                                                  ^^^^^^ storage.type.node_type - punctuation - meta.function-call :)
 
- )]
-#^ invalid.illegal.stray-bracket-end.xpath
+  )]
+(:^^ invalid.illegal.stray-bracket-end :)

--- a/syntax_test_xpath2.syntax-test
+++ b/syntax_test_xpath2.syntax-test
@@ -1,28 +1,31 @@
-# SYNTAX TEST "xpath.sublime-syntax"
-(/hello/descendant::world)[1]
-# <- meta.block.query.xpath punctuation.definition.arguments.begin.xpath.subexpression comment
-#^ meta.block.query.xpath punctuation.separator.xpath.location_step
-# ^^^^^ meta.block.query.xpath variable.parameter.xpath
-#       ^^^^^^^^^^^^ meta.block.query.xpath constant.language.xpath.axis_name
-#                   ^^^^^ meta.block.query.xpath variable.parameter.xpath
-#                        ^ meta.block.query.xpath punctuation.definition.arguments.end.xpath.subexpression comment
-#                         ^ xpath.predicate punctuation.definition.arguments.begin.xpath.predicate
-#                          ^ xpath.predicate constant.numeric.xpath
-#                           ^ xpath.predicate punctuation.definition.arguments.end.xpath.predicate
+(: SYNTAX TEST "xpath.sublime-syntax" :)
+  (/hello/descendant::world)[1]
+(:^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.query :)
+(:^ punctuation.section.arguments.begin.xpath.subexpression :)
+(: ^ punctuation.accessor.location_step :)
+(:  ^^^^^ variable.parameter :)
+(:        ^^^^^^^^^^^^ constant.language.axis_name :)
+(:                    ^^^^^ variable.parameter :)
+(:                         ^ punctuation.section.arguments.end.xpath.subexpression :)
+(:                          ^^^ meta.predicate :)
+(:                          ^ punctuation.section.arguments.begin.xpath.predicate :)
+(:                           ^ constant.numeric :)
+(:                            ^ punctuation.section.arguments.end.xpath.predicate :)
 
 / @ hello/ text () / ancestor :: test :*
-# ^ keyword.control.flow.xpath
-#   ^^^^^ keyword.control.flow.xpath
-#          ^^^^ storage.type.xpath.node_type
-#               ^^ storage.type.xpath.node_type
-#                    ^^^^^^^^ constant.language.xpath.axis_name
-#                             ^^ constant.language.xpath.axis_name
-#                                ^^^^ variable.parameter.xpath
-#                                     ^^ variable.parameter.xpath
- -3.div--(-.2)
-# ^^ query.xml.xpath constant.numeric.xpath
-#   ^^^ query.xml.xpath keyword.operator.xpath
-#         ^^^ query.xml.xpath constant.numeric.xpath
+(:^ keyword.control.flow :)
+(:  ^^^^^ keyword.control.flow :)
+(:         ^^^^ storage.type.node_type :)
+(:              ^^ storage.type.node_type :)
+(:                   ^^^^^^^^ constant.language.axis_name :)
+(:                            ^^ constant.language.axis_name :)
+(:                               ^^^^ variable.parameter :)
+(:                                    ^^ variable.parameter :)
+  -3.div--(-.2)
+(: ^^ constant.numeric :)
+(:   ^^^ keyword.operator :)
+(:         ^^^ constant.numeric :)
 /*[following::(bar)]
-# .^^^^^^^^^^^ constant.language.xpath.axis_name
-#             ^^^^^ query.xml.xpath invalid.illegal.unexpected_token.xpath
+(: ^^^^^^^^^^^ constant.language.axis_name :)
+(:            ^^^^ invalid.illegal.unexpected_token :)
+(:                ^^ invalid.illegal.stray-bracket-end :)

--- a/syntax_test_xpath3.syntax-test
+++ b/syntax_test_xpath3.syntax-test
@@ -1,49 +1,50 @@
-# SYNTAX TEST "xpath.sublime-syntax"
-.1 *2**
-# <- constant.numeric.xpath
-#^ constant.numeric.xpath
-#  ^ keyword.operator.xpath
-#   ^ constant.numeric.xpath
-#    ^ keyword.operator.xpath
-#     ^ variable.parameter.xpath
+(: SYNTAX TEST "xpath.sublime-syntax" :)
+  .1 *2**
+(:^^ constant.numeric :)
+(:   ^ keyword.operator :)
+(:    ^ constant.numeric :)
+(:     ^ keyword.operator :)
+(:      ^ variable.parameter :)
 +
-5mod2+
-# <- constant.numeric.xpath
-#^^^ keyword.operator.xpath
-#   ^ constant.numeric.xpath
+  5mod2+
+(:^ constant.numeric :)
+(: ^^^ keyword.operator :)
+(:    ^ constant.numeric :)
 
-/and/ *
-#^^^ variable.parameter.xpath
-#     ^ variable.parameter.xpath
+ /and/ *
+(:^^^ variable.parameter :)
+(:     ^ variable.parameter :)
 
 / for/../hello.world/ ns :foobar
-# ^^^ variable.parameter.xpath
-#     ^^ query.xml.xpath keyword.control.flow.xpath
-#        ^^^^^^^^^^^ variable.parameter.xpath
-#                     ^^^^^^^^^^ variable.parameter.xpath
+(:^^^ variable.parameter.xpath :)
+(:    ^^ keyword.control.flow.xpath :)
+(:       ^^^^^^^^^^^ variable.parameter.xpath :)
+(:                    ^^^^^^^^^^ variable.parameter.xpath :)
 
 //example[1]/*[starts-with(local-name(), "hello") and./text()and"hello[world][1]"+*
-# ^^^^^^^ variable.parameter.xpath
-#        ^ query.xml.xpath xpath.predicate punctuation.definition.arguments.begin.xpath.predicate comment
-#         ^ constant.numeric.xpath
-#          ^ query.xml.xpath xpath.predicate punctuation.definition.arguments.end.xpath.predicate comment
-#            ^ variable.parameter.xpath
-#             ^ query.xml.xpath xpath.predicate punctuation.definition.arguments.begin.xpath.predicate comment
-#              ^^^^^^^^^^^^^^^^^^^^^^^ query.xml.xpath xpath.predicate meta.function-call.xpath entity.name.function.xpath
-#                          ^^^^^^^^^^^ query.xml.xpath xpath.predicate meta.function-call.xpath meta.function-call.xpath entity.name.function.xpath
-#                                    ^ query.xml.xpath xpath.predicate meta.function-call.xpath meta.function-call.xpath entity.name.function.xpath punctuation.definition.arguments.begin.xpath.subexpression comment
-#                                     ^ query.xml.xpath xpath.predicate meta.function-call.xpath meta.function-call.xpath punctuation.definition.arguments.end.xpath.subexpression comment
-#                                      ^ query.xml.xpath xpath.predicate meta.function-call.xpath punctuation.separator.xpath.arguments
-#                                        ^^^^^^^ query.xml.xpath xpath.predicate meta.function-call.xpath string.quoted.double.xpath
-#                                               ^ query.xml.xpath xpath.predicate meta.function-call.xpath punctuation.definition.arguments.end.xpath.subexpression comment
-#                                                 ^^^ query.xml.xpath xpath.predicate keyword.operator.xpath
-#                                                    ^ query.xml.xpath xpath.predicate keyword.control.flow.xpath
-#                                                     ^ query.xml.xpath xpath.predicate punctuation.separator.xpath.location_step
-#                                                      ^^^^^^ query.xml.xpath xpath.predicate storage.type.xpath.node_type
-#                                                            ^^^ query.xml.xpath xpath.predicate keyword.operator.xpath
-#                                                               ^^^^^^^^^^^^^^^^^ query.xml.xpath xpath.predicate string.quoted.double.xpath
-#                                                                                ^ query.xml.xpath xpath.predicate keyword.operator.xpath
-#                                                                                 ^ query.xml.xpath xpath.predicate variable.parameter.xpath
+(:^^^^^^^ variable.parameter.xpath :)
+(:       ^^^ meta.predicate.xpath :)
+(:        ^ constant.numeric.xpath :)
+(:       ^ punctuation.section.arguments.begin.xpath.predicate :)
+(:         ^ punctuation.section.arguments.end.xpath.predicate :)
+(:           ^ variable.parameter.xpath :)
+(:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.predicate.xpath :)
+(:             ^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.xpath variable.function :)
+(:                         ^^^^^^^^^^^ meta.function-call.xpath meta.function-call.xpath :)
+(:                                   ^ punctuation.section.arguments.begin.xpath.subexpression :)
+(:                                    ^ punctuation.section.arguments.end.xpath.subexpression :)
+(:                                     ^ punctuation.separator.arguments.xpath :)
+(:                                       ^^^^^^^ string.quoted.double.xpath :)
+(:                                              ^ punctuation.section.arguments.end.xpath.subexpression :)
+(:                                                ^^^ keyword.operator.xpath :)
+(:                                                   ^ keyword.control.flow.xpath :)
+(:                                                    ^ punctuation.accessor.location_step.xpath :)
+(:                                                     ^^^^^^ storage.type.node_type.xpath :)
+(:                                                           ^^^ keyword.operator.xpath :)
+(:                                                              ^^^^^^^^^^^^^^^^^ string.quoted.double.xpath :)
+(:                                                                               ^ keyword.operator.xpath :)
+(:                                                                                ^ variable.parameter.xpath :)
 
 ///5*+2'hello'
-# ^^^^^^^^^^^^ query.xml.xpath xpath.predicate invalid.illegal.unexpected_token.xpath
+(:^^^^^^^^^^^^ meta.predicate.xpath invalid.illegal.unexpected_token.xpath :)
+(:            ^ meta.predicate.xpath - invalid :)

--- a/xpath.py
+++ b/xpath.py
@@ -517,6 +517,8 @@ def plugin_unloaded():
     for view in sublime.active_window().views():
         view.erase_status('xpath')
         view.erase_status('xpath_error')
+    global settings
+    settings.clear_on_change('reparse')
 
 def get_results_for_xpath_query_multiple_trees(query, tree_contexts, root_namespaces, **additional_variables):
     """Given a query string and a dictionary of document trees and their context elements, compile the xpath query and execute it for each document."""

--- a/xpath.sublime-syntax
+++ b/xpath.sublime-syntax
@@ -7,53 +7,62 @@ variables:
   Prefix: '(?:{{QName}}\s*:)?'
   NCName: '{{Prefix}}(?:{{QName}}|\*)'
   Attribute: '@\s*(?:{{NCName}})?'
-contexts: # NOTE: these scope names don't represent what they should, they are set for best syntax highlighting
+contexts:
+  prototype:
+    - include: comments
+  comments:
+    - match: '\(:'
+      scope: punctuation.definition.comment.begin.xpath
+      push:
+        - meta_scope: comment.block.xpath
+        - match: :\)
+          scope: punctuation.definition.comment.end.xpath
+          pop: true
+        - include: comments
   main:
-    - match: '#.*$'
-      scope: syntax_test.marker # needed to get syntax tests working properly, otherwise it treats the syntax test definition line as an xpath... https://github.com/SublimeTextIssues/Core/issues/1152
-    - match: '\]|\)'
+    - match: \]|\)
       scope: invalid.illegal.stray-bracket-end.xpath
     - match: ''
       push: base
   base_without_pop:
     - include: location_step
-    - match: '-*\('
-      scope: punctuation.definition.arguments.begin.xpath.subexpression comment
+    - match: -*\(
+      scope: punctuation.section.arguments.begin.xpath.subexpression
       set: [inside_subexpression, base_disallow_pop] # don't allow an opening parenthesis followed immediately by a closing parenthesis
-    - match: '(")([^"]*)(")'
+    - match: (")([^"]*)(")
       captures:
         0: string.quoted.double.xpath # Literal
         1: punctuation.definition.string.begin.xpath
         3: punctuation.definition.string.end.xpath
       set: operator
-    - match: "(')([^']*)(')"
+    - match: (')([^']*)(')
       captures:
         0: string.quoted.single.xpath # Literal
         1: punctuation.definition.string.begin.xpath
         3: punctuation.definition.string.end.xpath
       set: operator
-    - match: '-*(?:\d+\.\d*|\.?\d+)' # lxml allows '2', '2.', '.5', '2.5' and '---3' for example - '2.' is treated as '2.0'
+    - match: -*(?:\d+\.\d*|\.?\d+) # lxml allows '2', '2.', '.5', '2.5' and '---3' for example - '2.' is treated as '2.0'
       scope: constant.numeric.xpath # Number
       set: operator
-    - match: '\$({{QName}})?'
-      scope: entity.name.variable.xpath support.function.builtin.xpath.variable # VariableReference
+    - match: \$({{QName}})?
+      scope: variable.other.xpath # VariableReference
       set: operator_or_predicate_or_location_step
     - include: location_test
   inside_subexpression:
     - meta_scope: meta.block.query.xpath
-    - match: '\)'
-      scope: punctuation.definition.arguments.end.xpath.subexpression comment
+    - match: \)
+      scope: punctuation.section.arguments.end.xpath.subexpression
       set: operator_or_predicate_or_location_step
   base:
     - include: pop_me
     - include: base_without_pop
     - include: unexpected_token
   location_step:
-    - match: '/{1,2}'
-      scope: punctuation.separator.xpath.location_step
+    - match: /{1,2}
+      scope: punctuation.accessor.location_step.xpath
       set: location_test_or_invalid
   axis_step:
-    - match: '\.{1,2}'
+    - match: \.{1,2}
       scope: keyword.control.flow.xpath # AxisStep
       set: operator_or_location_step
   base_disallow_pop:
@@ -61,17 +70,17 @@ contexts: # NOTE: these scope names don't represent what they should, they are s
     - match: '[,\]\)]'
       scope: invalid.illegal.unexpected_token.xpath
   pop_me:
-    - match: '(?=[,\]\)])'
+    - match: (?=[,\]\)])
       pop: true
   operator:
-    - match: 'and|or|mod|div|\*|\||\+|-|!?=|<=?|>=?'
+    - match: and|or|mod|div|\*|\||\+|-|!?=|<=?|>=?
       scope: keyword.operator.xpath # Operator
       set: base_disallow_pop #_without_pop # show invalid end predicate when an operator is at the end of a predicate for example //*[a or ]
     - include: pop_me
     - include: unexpected_token
   operator_or_predicate:
-    - match: '\['
-      scope: punctuation.definition.arguments.begin.xpath.predicate comment
+    - match: \[
+      scope: punctuation.section.arguments.begin.xpath.predicate
       set: [inside_predicate, base_disallow_pop]
     - include: operator
   operator_or_predicate_or_location_step:
@@ -81,14 +90,14 @@ contexts: # NOTE: these scope names don't represent what they should, they are s
     - include: location_step
     - include: operator
   inside_predicate:
-    - meta_scope: xpath.predicate
-    - match: '\]'
-      scope: punctuation.definition.arguments.end.xpath.predicate comment
+    - meta_scope: meta.predicate.xpath
+    - match: \]
+      scope: punctuation.section.arguments.end.xpath.predicate
       set: operator_or_predicate_or_location_step
     - include: unexpected_token
   node_type:
-    - match: '(comment|text|processing-instruction|node)\s*\(\s*\)'
-      scope: storage.type.xpath.node_type # NodeType
+    - match: (comment|text|processing-instruction|node)\s*\(\s*\)
+      scope: storage.type.node_type.xpath # NodeType
       set: operator_or_predicate_or_location_step
   name_test:
     - match: '{{NCName}}'
@@ -104,17 +113,17 @@ contexts: # NOTE: these scope names don't represent what they should, they are s
     - match: '{{Attribute}}'
       scope: keyword.control.flow.xpath # Attribute
       set: operator_or_predicate_or_location_step
-    - match: '((?:ancestor(?:-or-self)?|attribute|child|descendant(?:-or-self)?|following(?:-sibling)?|namespace|parent|preceding(?:-sibling)?|self)\s*::)\s*'
+    - match: ((?:ancestor(?:-or-self)?|attribute|child|descendant(?:-or-self)?|following(?:-sibling)?|namespace|parent|preceding(?:-sibling)?|self)\s*::)\s*
       captures:
-        1: constant.language.xpath.axis_name # AxisName
+        1: constant.language.axis_name.xpath # AxisName
         2: variable.parameter.xpath # NameTest
         3: keyword.control.flow.xpath # Attribute
       set: node_test_or_invalid
     - include: node_type
-    - match: '({{Prefix}}{{QName}})\s*(\()'
+    - match: ({{Prefix}}{{QName}})\s*(\()
       captures:
-        0: entity.name.function.xpath # NameTest
-        2: punctuation.definition.arguments.begin.xpath.subexpression comment
+        0: variable.function.xpath # NameTest # TODO: scope known, built-in names differently to user defined functions
+        2: punctuation.section.arguments.begin.xpath.subexpression
       set: [inside_function, base]
     - include: name_test
     - include: axis_step
@@ -123,14 +132,14 @@ contexts: # NOTE: these scope names don't represent what they should, they are s
     - include: unexpected_token
   inside_function:
     - meta_scope: meta.function-call.xpath
-    - match: '\)'
-      scope: punctuation.definition.arguments.end.xpath.subexpression comment
+    - match: \)
+      scope: punctuation.section.arguments.end.xpath.subexpression
       set: operator_or_predicate_or_location_step
     - match: ','
-      scope: punctuation.separator.xpath.arguments comment
+      scope: punctuation.separator.arguments.xpath
       push: base
   unexpected_token:
     - match: '[)\]]'
       scope: invalid.illegal.stray-bracket-end.xpath
-    - match: '\S+'
+    - match: '[^)\]\s]+'
       scope: invalid.illegal.unexpected_token.xpath


### PR DESCRIPTION
This PR improves the syntax highlighting definition for XPath 1.0 by conforming more closely to the [official scope naming guidelines](https://www.sublimetext.com/docs/3/scope_naming.html). This means that it no longer enforces that brackets/parens would look like comments. If users desire this behavior back, they can easily customize their color scheme.

I've also added highlighting for comments from the XPath 2.0 spec, because it makes the syntax tests much nicer to look at, and could help people that generally work with an XPath 2.0 engine but write XPath 1.0 compatible queries that they want to test in ST. (i.e. a future change could strip these comments out before passing the query to the lxml xpath engine)